### PR TITLE
feat(family-invite) 가족 초대 기능 작업

### DIFF
--- a/.cursor/rules/rules.mdc
+++ b/.cursor/rules/rules.mdc
@@ -1,11 +1,17 @@
+---
+alwaysApply: true
+---
+
 # 우리집 가계부 - Cursor AI 개발 규칙
 
 ## 🎯 프로젝트 개요
+
 Next.js 15 + TypeScript + Prisma ORM + Tailwind CSS를 사용한 가족 가계부 애플리케이션
 
 ## 📋 코딩 컨벤션
 
 ### 1. 데이터베이스 & API 컨벤션
+
 - **모든 데이터베이스 테이블명과 컬럼명은 snake_case 사용**
   - 예: `family_members`, `created_at`, `user_id`, `family_uuid`
 - **UUID 기반 관계 설정**: 모든 테이블 간 조인은 UUID를 통해 수행
@@ -13,28 +19,33 @@ Next.js 15 + TypeScript + Prisma ORM + Tailwind CSS를 사용한 가족 가계�
 - **Soft Delete 패턴**: 모든 비즈니스 테이블에 `deleted_at` 컬럼 사용
 
 ### 2. TypeScript 타입 안전성
+
 - **절대 `any` 타입 사용 금지** - `unknown` 또는 정확한 타입 사용
 - **Prisma 공식 에러 타입 사용**: `PrismaClientKnownRequestError` 등
 - **Zod 스키마 검증**: `error.issues` 사용 (not `error.errors`)
 
 ### 3. 아키텍처 패턴
+
 - **Repository 패턴**: 데이터 액세스 레이어 분리
 - **Service 패턴**: 비즈니스 로직 캡슐화
 - **의존성 주입**: Container를 통한 인스턴스 관리
 
 ### 4. API 설계
+
 - **RESTful API 설계**
 - **통일된 에러 처리**: `handlePrismaError`, `handleValidationError` 사용
 - **BigInt 자동 직렬화**: API 응답에서 BigInt → String 변환
 - **인증 래퍼**: `withAuth` 함수로 인증 통합 처리
 
 ### 5. 프론트엔드 컨벤션
+
 - **React Hooks 최적화**: `useCallback`, `useMemo` 적절히 사용
 - **Next.js Image 컴포넌트**: `<img>` 태그 대신 `<Image />` 사용
 - **Tailwind CSS**: 일관된 스타일링
 - **shadcn/ui**: UI 컴포넌트 라이브러리 활용
 
 ## 🛠 기술 스택
+
 - **Frontend**: Next.js 15, React 19, TypeScript, Tailwind CSS v3
 - **Backend**: Next.js API Routes, Prisma ORM
 - **Database**: Supabase (PostgreSQL)
@@ -43,6 +54,7 @@ Next.js 15 + TypeScript + Prisma ORM + Tailwind CSS를 사용한 가족 가계�
 - **Package Manager**: pnpm
 
 ## 📁 프로젝트 구조
+
 ```
 src/
 ├── app/                 # Next.js App Router
@@ -62,6 +74,7 @@ src/
 ## 🚀 개발 가이드라인
 
 ### 1. 새로운 API 엔드포인트 추가 시
+
 1. Repository 인터페이스 정의
 2. Repository 구현체 작성
 3. Service 레이어 구현
@@ -69,24 +82,28 @@ src/
 5. 에러 처리 및 타입 안전성 확보
 
 ### 2. 데이터베이스 스키마 변경 시
+
 1. Prisma 스키마 수정 (snake_case 준수)
 2. `npx prisma db push` 또는 마이그레이션 생성
 3. Repository 구현체 업데이트
 4. 타입 정의 확인
 
 ### 3. 컴포넌트 개발 시
+
 1. TypeScript Props 인터페이스 정의
 2. React Hooks 의존성 최적화
 3. 에러 바운더리 고려
 4. 접근성 (a11y) 고려
 
 ## ⚠️ 주의사항
+
 - **Production 데이터베이스에서 `--force-reset` 절대 금지**
 - **환경변수 (.env.local) 커밋 금지**
 - **API 키 및 민감한 정보 노출 금지**
 - **타입 안전성을 위해 런타임 검증 필수**
 
 ## 🔧 유용한 명령어
+
 ```bash
 # 개발 서버 실행
 pnpm dev
@@ -114,11 +131,13 @@ vercel
 ## 🗄️ 데이터베이스 스키마 규칙
 
 ### 테이블 및 컬럼 명명 규칙
+
 - **테이블명**: snake_case (예: `family_members`, `verification_tokens`)
 - **컬럼명**: snake_case (예: `user_id`, `created_at`, `family_uuid`)
 - **관계 컬럼**: UUID 기반 (예: `family_uuid`, `category_uuid`)
 
 ### 스키마 예시
+
 ```prisma
 model FamilyMember {
   id          BigInt    @id @default(autoincrement())
@@ -140,28 +159,31 @@ model FamilyMember {
 ## 🔄 최근 주요 개선사항 (2025-12-21)
 
 ### Repository 레이어 아키텍처 개선
+
 - **문제**: Repository에서 `serialize()` 함수 사용으로 Date 객체가 문자열로 변환되어 ORM 이점 상실
-- **해결**: 
+- **해결**:
   - Prisma가 제공하는 Date 객체를 그대로 유지
   - BigInt와 Decimal만 필요 시 문자열로 변환
   - `date.toLocaleDateString is not a function` 오류 해결
 
 ### 타입 안전성 개선
+
 ```typescript
 // ❌ 기존: 직렬화로 인한 타입 혼동
 interface ExpenseData {
-  date: Date | string  // 불안정한 유니온 타입
-  amount: string | number
+  date: Date | string; // 불안정한 유니온 타입
+  amount: string | number;
 }
 
 // ✅ 개선: ORM 레이어에서 명확한 타입 유지
 interface ExpenseData {
-  date: Date           // Date 객체 유지
-  amount: string       // Repository에서 일관된 문자열 변환
+  date: Date; // Date 객체 유지
+  amount: string; // Repository에서 일관된 문자열 변환
 }
 ```
 
 ### 데이터 흐름 최적화
+
 ```
 Prisma ORM → Repository → Service → UI
      ↓            ↓        ↓       ↓
@@ -171,18 +193,235 @@ Prisma ORM → Repository → Service → UI
 ```
 
 ### 핵심 원칙
+
 1. **ORM 이점 활용**: Prisma의 타입 안전성과 Date 객체를 최대한 활용
 2. **최소 변환**: 반드시 필요한 경우(BigInt, Decimal)만 문자열로 변환
 3. **일관된 인터페이스**: Repository 레이어에서 일관된 데이터 형태 제공
 4. **API 응답 시에만 Serialization**: 네트워크 전송 시에만 serialize 적용
 
 ### 중요 파일들
+
 - `src/repositories/implementations/expense.repository.impl.ts`: Date 객체 유지 로직
 - `src/repositories/interfaces/expense.repository.ts`: 정확한 타입 정의
 - `src/components/expenses/ExpenseList.tsx`: Date 객체 직접 사용
 - `src/lib/serialization.ts`: API 응답용 직렬화 함수 (Repository에서 사용 금지)
 
 ### 문제 해결 과정
+
+1. **문제 발견**: `date.toLocaleDateString is not a function` 에러 발생
+2. **원인 분석**: Repository에서 serialize 함수로 Date → string 변환
+3. **근본 해결**: ORM 레이어에서 Date 객체 그대로 유지
+4. **타입 정리**: 명확한 Date 타입 정의로 타입 안전성 확보
+5. **빌드 검증**: 프로덕션 빌드 성공 확인
+
+이 개선으로 인해 ORM의 장점을 완전히 활용하면서 타입 안전성도 크게 향상되었습니다.
+
+# 우리집 가계부 - Cursor AI 개발 규칙
+
+## 🎯 프로젝트 개요
+
+Next.js 15 + TypeScript + Prisma ORM + Tailwind CSS를 사용한 가족 가계부 애플리케이션
+
+## 📋 코딩 컨벤션
+
+### 1. 데이터베이스 & API 컨벤션
+
+- **모든 데이터베이스 테이블명과 컬럼명은 snake_case 사용**
+  - 예: `family_members`, `created_at`, `user_id`, `family_uuid`
+- **UUID 기반 관계 설정**: 모든 테이블 간 조인은 UUID를 통해 수행
+  - 예: `family_uuid`, `category_uuid` 등
+- **Soft Delete 패턴**: 모든 비즈니스 테이블에 `deleted_at` 컬럼 사용
+
+### 2. TypeScript 타입 안전성
+
+- **절대 `any` 타입 사용 금지** - `unknown` 또는 정확한 타입 사용
+- **Prisma 공식 에러 타입 사용**: `PrismaClientKnownRequestError` 등
+- **Zod 스키마 검증**: `error.issues` 사용 (not `error.errors`)
+
+### 3. 아키텍처 패턴
+
+- **Repository 패턴**: 데이터 액세스 레이어 분리
+- **Service 패턴**: 비즈니스 로직 캡슐화
+- **의존성 주입**: Container를 통한 인스턴스 관리
+
+### 4. API 설계
+
+- **RESTful API 설계**
+- **통일된 에러 처리**: `handlePrismaError`, `handleValidationError` 사용
+- **BigInt 자동 직렬화**: API 응답에서 BigInt → String 변환
+- **인증 래퍼**: `withAuth` 함수로 인증 통합 처리
+
+### 5. 프론트엔드 컨벤션
+
+- **React Hooks 최적화**: `useCallback`, `useMemo` 적절히 사용
+- **Next.js Image 컴포넌트**: `<img>` 태그 대신 `<Image />` 사용
+- **Tailwind CSS**: 일관된 스타일링
+- **shadcn/ui**: UI 컴포넌트 라이브러리 활용
+
+## 🛠 기술 스택
+
+- **Frontend**: Next.js 15, React 19, TypeScript, Tailwind CSS v3
+- **Backend**: Next.js API Routes, Prisma ORM
+- **Database**: Supabase (PostgreSQL)
+- **Authentication**: NextAuth.js (Google OAuth)
+- **Deployment**: Vercel
+- **Package Manager**: pnpm
+
+## 📁 프로젝트 구조
+
+```
+src/
+├── app/                 # Next.js App Router
+│   ├── api/            # API Routes
+│   └── (pages)/        # Page Components
+├── components/         # React Components
+│   ├── ui/            # shadcn/ui Components
+│   ├── common/        # 공통 컴포넌트
+│   └── feature/       # 기능별 컴포넌트
+├── lib/               # 유틸리티 함수
+├── repositories/      # 데이터 액세스 레이어
+├── services/          # 비즈니스 로직 레이어
+├── container/         # 의존성 주입 컨테이너
+└── types/            # TypeScript 타입 정의
+```
+
+## 🚀 개발 가이드라인
+
+### 1. 새로운 API 엔드포인트 추가 시
+
+1. Repository 인터페이스 정의
+2. Repository 구현체 작성
+3. Service 레이어 구현
+4. API Route 작성 (`withAuth` 사용)
+5. 에러 처리 및 타입 안전성 확보
+
+### 2. 데이터베이스 스키마 변경 시
+
+1. Prisma 스키마 수정 (snake_case 준수)
+2. `npx prisma db push` 또는 마이그레이션 생성
+3. Repository 구현체 업데이트
+4. 타입 정의 확인
+
+### 3. 컴포넌트 개발 시
+
+1. TypeScript Props 인터페이스 정의
+2. React Hooks 의존성 최적화
+3. 에러 바운더리 고려
+4. 접근성 (a11y) 고려
+
+## ⚠️ 주의사항
+
+- **Production 데이터베이스에서 `--force-reset` 절대 금지**
+- **환경변수 (.env.local) 커밋 금지**
+- **API 키 및 민감한 정보 노출 금지**
+- **타입 안전성을 위해 런타임 검증 필수**
+
+## 🔧 유용한 명령어
+
+```bash
+# 개발 서버 실행
+pnpm dev
+
+# 데이터베이스 스키마 적용
+pnpm db:push
+
+# Prisma Studio 실행
+pnpm db:studio
+
+# 마이그레이션 생성 및 적용
+pnpm db:migrate
+
+# Prisma Client 생성
+pnpm db:generate
+
+# 스키마 검증
+pnpm db:validate
+
+# 빌드 및 배포
+pnpm build
+vercel
+```
+
+## 🗄️ 데이터베이스 스키마 규칙
+
+### 테이블 및 컬럼 명명 규칙
+
+- **테이블명**: snake_case (예: `family_members`, `verification_tokens`)
+- **컬럼명**: snake_case (예: `user_id`, `created_at`, `family_uuid`)
+- **관계 컬럼**: UUID 기반 (예: `family_uuid`, `category_uuid`)
+
+### 스키마 예시
+
+```prisma
+model FamilyMember {
+  id          BigInt    @id @default(autoincrement())
+  uuid        String    @unique @default(uuid()) @db.Uuid
+  family_uuid String    @db.Uuid @map("family_uuid")
+  user_id     String    @map("user_id")
+  role        String    @default("member")
+  joined_at   DateTime  @default(now()) @map("joined_at")
+  deleted_at  DateTime? @map("deleted_at")
+
+  family Family @relation("FamilyMembers", fields: [family_uuid], references: [uuid])
+  user   User   @relation("UserFamilyMembers", fields: [user_id], references: [id])
+
+  @@unique([family_uuid, user_id])
+  @@map("family_members")
+}
+```
+
+## 🔄 최근 주요 개선사항 (2025-12-21)
+
+### Repository 레이어 아키텍처 개선
+
+- **문제**: Repository에서 `serialize()` 함수 사용으로 Date 객체가 문자열로 변환되어 ORM 이점 상실
+- **해결**:
+  - Prisma가 제공하는 Date 객체를 그대로 유지
+  - BigInt와 Decimal만 필요 시 문자열로 변환
+  - `date.toLocaleDateString is not a function` 오류 해결
+
+### 타입 안전성 개선
+
+```typescript
+// ❌ 기존: 직렬화로 인한 타입 혼동
+interface ExpenseData {
+  date: Date | string; // 불안정한 유니온 타입
+  amount: string | number;
+}
+
+// ✅ 개선: ORM 레이어에서 명확한 타입 유지
+interface ExpenseData {
+  date: Date; // Date 객체 유지
+  amount: string; // Repository에서 일관된 문자열 변환
+}
+```
+
+### 데이터 흐름 최적화
+
+```
+Prisma ORM → Repository → Service → UI
+     ↓            ↓        ↓       ↓
+   Date         Date    Date    Date  ✅ Date 객체 유지
+   Decimal   → string  string  string ✅ 일관된 변환
+   BigInt    → string  string  string ✅ 일관된 변환
+```
+
+### 핵심 원칙
+
+1. **ORM 이점 활용**: Prisma의 타입 안전성과 Date 객체를 최대한 활용
+2. **최소 변환**: 반드시 필요한 경우(BigInt, Decimal)만 문자열로 변환
+3. **일관된 인터페이스**: Repository 레이어에서 일관된 데이터 형태 제공
+4. **API 응답 시에만 Serialization**: 네트워크 전송 시에만 serialize 적용
+
+### 중요 파일들
+
+- `src/repositories/implementations/expense.repository.impl.ts`: Date 객체 유지 로직
+- `src/repositories/interfaces/expense.repository.ts`: 정확한 타입 정의
+- `src/components/expenses/ExpenseList.tsx`: Date 객체 직접 사용
+- `src/lib/serialization.ts`: API 응답용 직렬화 함수 (Repository에서 사용 금지)
+
+### 문제 해결 과정
+
 1. **문제 발견**: `date.toLocaleDateString is not a function` 에러 발생
 2. **원인 분석**: Repository에서 serialize 함수로 Date → string 변환
 3. **근본 해결**: ORM 레이어에서 Date 객체 그대로 유지

--- a/prisma/migrations/0002_add_family_invite_and_member_status/migration.sql
+++ b/prisma/migrations/0002_add_family_invite_and_member_status/migration.sql
@@ -1,0 +1,38 @@
+-- CreateTable
+CREATE TABLE "family_invites" (
+    "id" BIGSERIAL NOT NULL,
+    "uuid" UUID NOT NULL,
+    "family_uuid" UUID NOT NULL,
+    "invite_code" VARCHAR(32) NOT NULL,
+    "invited_by" UUID NOT NULL,
+    "expires_at" TIMESTAMP(3) NOT NULL,
+    "usage_limit" INTEGER,
+    "used_count" INTEGER NOT NULL DEFAULT 0,
+    "is_active" BOOLEAN NOT NULL DEFAULT true,
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
+    "deleted_at" TIMESTAMP(3),
+
+    CONSTRAINT "family_invites_pkey" PRIMARY KEY ("id")
+);
+
+-- AlterTable
+ALTER TABLE "family_members" ADD COLUMN "status" VARCHAR(20) NOT NULL DEFAULT 'pending';
+
+-- CreateIndex
+CREATE UNIQUE INDEX "family_invites_uuid_key" ON "family_invites"("uuid");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "family_invites_invite_code_key" ON "family_invites"("invite_code");
+
+-- CreateIndex
+CREATE INDEX "family_invites_invite_code_idx" ON "family_invites"("invite_code");
+
+-- CreateIndex
+CREATE INDEX "family_invites_family_uuid_idx" ON "family_invites"("family_uuid");
+
+-- AddForeignKey
+ALTER TABLE "family_invites" ADD CONSTRAINT "family_invites_family_uuid_fkey" FOREIGN KEY ("family_uuid") REFERENCES "families"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "family_invites" ADD CONSTRAINT "family_invites_invited_by_fkey" FOREIGN KEY ("invited_by") REFERENCES "users"("uuid") ON DELETE RESTRICT ON UPDATE CASCADE;

--- a/prisma/migrations/0003_add_member_enums/migration.sql
+++ b/prisma/migrations/0003_add_member_enums/migration.sql
@@ -1,0 +1,12 @@
+-- CreateEnum
+CREATE TYPE "MemberStatus" AS ENUM ('pending', 'approved', 'rejected', 'active');
+
+-- CreateEnum
+CREATE TYPE "MemberRole" AS ENUM ('admin', 'member');
+
+-- AlterTable
+ALTER TABLE "family_members" 
+  ALTER COLUMN "role" TYPE "MemberRole" USING "role"::"MemberRole",
+  ALTER COLUMN "role" SET DEFAULT 'member',
+  ALTER COLUMN "status" TYPE "MemberStatus" USING "status"::"MemberStatus",
+  ALTER COLUMN "status" SET DEFAULT 'pending';

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -80,6 +80,7 @@ model User {
   deletedAt     DateTime?      @map("deleted_at")
   accounts      Account[]
   familyMembers FamilyMember[] @relation("UserFamilyMembers")
+  invites       FamilyInvite[] @relation("UserInvites")
   sessions      Session[]
 
   @@map("users")
@@ -95,23 +96,58 @@ model Family {
   categories Category[]     @relation("FamilyCategories")
   expenses   Expense[]      @relation("FamilyExpenses")
   members    FamilyMember[] @relation("FamilyMembers")
+  invites    FamilyInvite[] @relation("FamilyInvites")
 
   @@map("families")
 }
 
+enum MemberStatus {
+  pending
+  approved
+  rejected
+  active
+}
+
+enum MemberRole {
+  admin
+  member
+}
+
 model FamilyMember {
-  id         BigInt    @id @default(autoincrement())
-  uuid       String    @unique @default(uuid()) @db.Uuid
-  familyUuid String    @map("family_uuid") @db.Uuid
-  userUuid   String    @map("user_uuid") @db.Uuid // User.uuid 참조
-  role       String    @default("member") @db.VarChar(20)
-  joinedAt   DateTime  @default(now()) @map("joined_at")
-  deletedAt  DateTime? @map("deleted_at")
-  family     Family    @relation("FamilyMembers", fields: [familyUuid], references: [uuid])
-  user       User      @relation("UserFamilyMembers", fields: [userUuid], references: [uuid])
+  id         BigInt       @id @default(autoincrement())
+  uuid       String       @unique @default(uuid()) @db.Uuid
+  familyUuid String       @map("family_uuid") @db.Uuid
+  userUuid   String       @map("user_uuid") @db.Uuid // User.uuid 참조
+  role       MemberRole   @default(member)
+  status     MemberStatus @default(pending)
+  joinedAt   DateTime     @default(now()) @map("joined_at")
+  deletedAt  DateTime?    @map("deleted_at")
+  family     Family       @relation("FamilyMembers", fields: [familyUuid], references: [uuid])
+  user       User         @relation("UserFamilyMembers", fields: [userUuid], references: [uuid])
 
   @@unique([familyUuid, userUuid])
   @@map("family_members")
+}
+
+model FamilyInvite {
+  id         BigInt    @id @default(autoincrement())
+  uuid       String    @unique @default(uuid()) @db.Uuid
+  familyUuid String    @map("family_uuid") @db.Uuid
+  inviteCode String    @unique @map("invite_code") @db.VarChar(32) // 초대 링크용 고유 코드
+  invitedBy  String    @map("invited_by") @db.Uuid // 초대한 사용자의 UUID
+  expiresAt  DateTime  @map("expires_at") // 초대 링크 만료 시간
+  usageLimit Int?      @map("usage_limit") // 사용 횟수 제한 (null이면 무제한)
+  usedCount  Int       @default(0) @map("used_count") // 사용된 횟수
+  isActive   Boolean   @default(true) @map("is_active") // 활성화 상태
+  createdAt  DateTime  @default(now()) @map("created_at")
+  updatedAt  DateTime  @updatedAt @map("updated_at")
+  deletedAt  DateTime? @map("deleted_at")
+  family     Family    @relation("FamilyInvites", fields: [familyUuid], references: [uuid])
+  inviter    User      @relation("UserInvites", fields: [invitedBy], references: [uuid])
+
+  @@index([inviteCode])
+  @@index([familyUuid])
+  @@map("family_invites")
 }
 
 model Category {

--- a/src/app/actions/family-invite-actions.ts
+++ b/src/app/actions/family-invite-actions.ts
@@ -1,0 +1,301 @@
+"use server";
+
+import { familyInviteService } from "@/container";
+import { auth } from "@/lib/auth";
+import { MemberStatus } from "@/types/enums";
+import { revalidatePath } from "next/cache";
+import { redirect } from "next/navigation";
+import { z } from "zod";
+
+// 초대 링크 생성 스키마
+const createInviteSchema = z.object({
+  familyUuid: z.string().uuid("유효한 가족 UUID를 입력해주세요."),
+  expiresInDays: z.coerce.number().int().min(1).max(30).optional(),
+  usageLimit: z.coerce.number().int().min(1).optional(),
+});
+
+// 초대 코드 가입 스키마
+const joinFamilySchema = z.object({
+  inviteCode: z.string().min(1, "초대 코드를 입력해주세요."),
+});
+
+// 멤버 승인/거절 스키마
+const manageMemberSchema = z.object({
+  familyUuid: z.string().uuid("유효한 가족 UUID를 입력해주세요."),
+  userUuid: z.string().uuid("유효한 사용자 UUID를 입력해주세요."),
+});
+
+export interface ActionResult<T = unknown> {
+  success: boolean;
+  message: string;
+  data?: T;
+  errors?: string[];
+}
+
+/**
+ * 초대 링크 생성 서버 액션
+ */
+export async function createInviteAction(
+  formData: FormData
+): Promise<ActionResult> {
+  try {
+    const session = await auth();
+    if (!session?.user?.uuid) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const rawData = {
+      familyUuid: formData.get("familyUuid"),
+      expiresInDays: formData.get("expiresInDays"),
+      usageLimit: formData.get("usageLimit"),
+    };
+
+    const validatedData = createInviteSchema.parse(rawData);
+
+    const invite = await familyInviteService.createInvite({
+      ...validatedData,
+      invitedBy: session.user.uuid,
+    });
+
+    revalidatePath("/families/manage");
+
+    return {
+      success: true,
+      message: "초대 링크가 생성되었습니다.",
+      data: {
+        inviteCode: invite.inviteCode,
+        expiresAt: invite.expiresAt,
+      },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        message: "입력 데이터가 올바르지 않습니다.",
+        errors: error.issues.map((issue) => issue.message),
+      };
+    }
+
+    if (error instanceof Error) {
+      return {
+        success: false,
+        message: error.message,
+      };
+    }
+
+    console.error("Error creating invite:", error);
+    return {
+      success: false,
+      message: "초대 링크 생성 중 오류가 발생했습니다.",
+    };
+  }
+}
+
+/**
+ * 가족 가입 신청 서버 액션
+ */
+export async function joinFamilyAction(
+  formData: FormData
+): Promise<ActionResult> {
+  try {
+    const session = await auth();
+    if (!session?.user?.uuid) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const rawData = {
+      inviteCode: formData.get("inviteCode"),
+    };
+
+    const validatedData = joinFamilySchema.parse(rawData);
+
+    const result = await familyInviteService.joinFamily({
+      inviteCode: validatedData.inviteCode,
+      userUuid: session.user.uuid,
+    });
+
+    if (result.success) {
+      revalidatePath("/families");
+      if (result.memberStatus === MemberStatus.ACTIVE.code) {
+        redirect("/families");
+      }
+    }
+
+    return {
+      success: result.success,
+      message: result.message,
+      data: { memberStatus: result.memberStatus },
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        message: "입력 데이터가 올바르지 않습니다.",
+        errors: error.issues.map((issue) => issue.message),
+      };
+    }
+
+    console.error("Error joining family:", error);
+    return {
+      success: false,
+      message: "가족 가입 신청 중 오류가 발생했습니다.",
+    };
+  }
+}
+
+/**
+ * 멤버 승인 서버 액션
+ */
+export async function approveMemberAction(
+  formData: FormData
+): Promise<ActionResult> {
+  try {
+    const session = await auth();
+    if (!session?.user?.uuid) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const rawData = {
+      familyUuid: formData.get("familyUuid"),
+      userUuid: formData.get("userUuid"),
+    };
+
+    const validatedData = manageMemberSchema.parse(rawData);
+
+    const result = await familyInviteService.approveMember(
+      validatedData.familyUuid,
+      validatedData.userUuid,
+      session.user.uuid
+    );
+
+    if (result.success) {
+      revalidatePath("/families/manage");
+    }
+
+    return {
+      success: result.success,
+      message: result.message,
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        message: "입력 데이터가 올바르지 않습니다.",
+        errors: error.issues.map((issue) => issue.message),
+      };
+    }
+
+    console.error("Error approving member:", error);
+    return {
+      success: false,
+      message: "멤버 승인 중 오류가 발생했습니다.",
+    };
+  }
+}
+
+/**
+ * 멤버 거절 서버 액션
+ */
+export async function rejectMemberAction(
+  formData: FormData
+): Promise<ActionResult> {
+  try {
+    const session = await auth();
+    if (!session?.user?.uuid) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const rawData = {
+      familyUuid: formData.get("familyUuid"),
+      userUuid: formData.get("userUuid"),
+    };
+
+    const validatedData = manageMemberSchema.parse(rawData);
+
+    const result = await familyInviteService.rejectMember(
+      validatedData.familyUuid,
+      validatedData.userUuid,
+      session.user.uuid
+    );
+
+    if (result.success) {
+      revalidatePath("/families/manage");
+    }
+
+    return {
+      success: result.success,
+      message: result.message,
+    };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return {
+        success: false,
+        message: "입력 데이터가 올바르지 않습니다.",
+        errors: error.issues.map((issue) => issue.message),
+      };
+    }
+
+    console.error("Error rejecting member:", error);
+    return {
+      success: false,
+      message: "멤버 거절 중 오류가 발생했습니다.",
+    };
+  }
+}
+
+/**
+ * 초대 링크 비활성화 서버 액션
+ */
+export async function deactivateInviteAction(
+  formData: FormData
+): Promise<ActionResult> {
+  try {
+    const session = await auth();
+    if (!session?.user?.uuid) {
+      return {
+        success: false,
+        message: "로그인이 필요합니다.",
+      };
+    }
+
+    const inviteUuid = formData.get("inviteUuid") as string;
+    if (!inviteUuid) {
+      return {
+        success: false,
+        message: "초대 UUID가 필요합니다.",
+      };
+    }
+
+    const result = await familyInviteService.deactivateInvite(
+      inviteUuid,
+      session.user.uuid
+    );
+
+    if (result.success) {
+      revalidatePath("/families/manage");
+    }
+
+    return {
+      success: result.success,
+      message: result.message,
+    };
+  } catch (error) {
+    console.error("Error deactivating invite:", error);
+    return {
+      success: false,
+      message: "초대 링크 비활성화 중 오류가 발생했습니다.",
+    };
+  }
+}

--- a/src/app/families/manage/page.tsx
+++ b/src/app/families/manage/page.tsx
@@ -1,0 +1,232 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { familyService, familyInviteService } from "@/container";
+import { CreateInviteForm } from "@/components/family-invites/CreateInviteForm";
+import { PendingMembersList } from "@/components/family-invites/PendingMembersList";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Users, Link2 } from "lucide-react";
+import { MemberStatus, MemberRole } from "@/types/enums";
+
+export default async function FamilyManagePage() {
+  const session = await auth();
+
+  console.log("🔍 Debug - session:", {
+    exists: !!session,
+    userId: session?.user?.id,
+    userUuid: session?.user?.uuid,
+  });
+
+  if (!session?.user?.uuid) {
+    console.log("❌ No session or user uuid, redirecting to signin");
+    redirect("/api/auth/signin");
+  }
+
+  try {
+    // 현재 사용자의 가족 정보 조회 (authId 사용)
+    console.log("🔍 Fetching family for user:", session.user.id);
+    const family = await familyService.getFamilyByUserId(session.user.id);
+
+    console.log("🔍 Family result:", {
+      exists: !!family,
+      familyName: family?.name,
+      membersCount: family?.members?.length,
+    });
+
+    if (!family) {
+      console.log("❌ No family found, redirecting to create");
+      redirect("/families/create");
+    }
+
+    // 관리자 권한 확인
+    console.log("🔍 Checking admin rights for user:", session.user.id);
+    console.log(
+      "🔍 Family members:",
+      family.members.map((m) => ({
+        userId: m.user.id,
+        role: m.role,
+        status: m.status,
+        name: m.user.name,
+      }))
+    );
+
+    const isAdmin = family.members.some((member) => {
+      const userMatch = member.user.id === session.user.id;
+      const roleMatch = member.role.code === MemberRole.ADMIN.code;
+      const statusMatch = member.status.code === MemberStatus.ACTIVE.code;
+
+      console.log("🔍 Member check:", {
+        memberUserId: member.user.id,
+        sessionUserId: session.user.id,
+        userMatch,
+        memberRole: member.role.code,
+        expectedRole: MemberRole.ADMIN.code,
+        roleMatch,
+        memberStatus: member.status.code,
+        expectedStatus: MemberStatus.ACTIVE.code,
+        statusMatch,
+        allMatch: userMatch && roleMatch && statusMatch,
+      });
+
+      return userMatch && roleMatch && statusMatch;
+    });
+
+    console.log("🔍 Admin check result:", isAdmin);
+
+    if (!isAdmin) {
+      console.log("❌ Not admin, redirecting to families");
+      redirect("/families");
+    }
+
+    // 대기 중인 멤버 목록 조회
+    const pendingMembers = await familyInviteService.getPendingMembers(
+      family.uuid,
+      session.user.uuid
+    );
+
+    // 활성 초대 링크 목록 조회
+    const activeInvites = await familyInviteService.getActiveInvites(
+      family.uuid,
+      session.user.uuid
+    );
+
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-4xl">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold mb-2">가족 관리</h1>
+          <p className="text-muted-foreground">
+            {family.name} 가족의 멤버와 초대 링크를 관리할 수 있습니다.
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* 초대 링크 생성 */}
+          <div className="space-y-6">
+            <CreateInviteForm familyUuid={family.uuid} />
+
+            {/* 활성 초대 링크 목록 */}
+            {activeInvites && activeInvites.length > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="flex items-center gap-2">
+                    <Link2 className="w-5 h-5" />
+                    활성 초대 링크 ({activeInvites.length})
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <div className="space-y-3">
+                    {activeInvites.map((invite) => (
+                      <div
+                        key={invite.uuid}
+                        className="p-3 border rounded-lg space-y-2"
+                      >
+                        <div className="flex justify-between items-start">
+                          <div>
+                            <p className="font-mono text-sm bg-muted px-2 py-1 rounded">
+                              {invite.inviteCode}
+                            </p>
+                            <p className="text-xs text-muted-foreground mt-1">
+                              만료:{" "}
+                              {invite.expiresAt.toLocaleDateString("ko-KR")}
+                            </p>
+                          </div>
+                          <Badge variant="secondary">
+                            {invite.usedCount}
+                            {invite.usageLimit
+                              ? ` / ${invite.usageLimit}`
+                              : ""}{" "}
+                            사용
+                          </Badge>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+          </div>
+
+          {/* 대기 중인 멤버 관리 */}
+          <div className="space-y-6">
+            <PendingMembersList
+              familyUuid={family.uuid}
+              pendingMembers={(pendingMembers || []).map((member) => ({
+                ...member,
+                role: MemberRole.fromCode(member.role.toString()),
+                status: MemberStatus.fromCode(member.status.toString()),
+              }))}
+            />
+
+            {/* 현재 멤버 목록 */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2">
+                  <Users className="w-5 h-5" />
+                  현재 멤버 (
+                  {
+                    family.members.filter(
+                      (m) => m.status === MemberStatus.ACTIVE
+                    ).length
+                  }
+                  )
+                </CardTitle>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-3">
+                  {family.members
+                    .filter((member) => member.status === MemberStatus.ACTIVE)
+                    .map((member) => (
+                      <div
+                        key={member.id}
+                        className="flex items-center justify-between p-3 border rounded-lg"
+                      >
+                        <div className="flex items-center gap-3">
+                          <Avatar>
+                            <AvatarImage src={member.user.image || undefined} />
+                            <AvatarFallback>
+                              {member.user.name?.charAt(0) ||
+                                member.user.email?.charAt(0) ||
+                                "?"}
+                            </AvatarFallback>
+                          </Avatar>
+
+                          <div>
+                            <div className="flex items-center gap-2">
+                              <span className="font-medium">
+                                {member.user.name || member.user.email}
+                              </span>
+                              {member.user.id === session.user.id && (
+                                <Badge variant="outline">나</Badge>
+                              )}
+                            </div>
+                            <p className="text-sm text-muted-foreground">
+                              가입일:{" "}
+                              {member.joinedAt.toLocaleDateString("ko-KR")}
+                            </p>
+                          </div>
+                        </div>
+
+                        <Badge
+                          variant={
+                            member.role === MemberRole.ADMIN
+                              ? "default"
+                              : "secondary"
+                          }
+                        >
+                          {member.role === MemberRole.ADMIN ? "관리자" : "멤버"}
+                        </Badge>
+                      </div>
+                    ))}
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+        </div>
+      </div>
+    );
+  } catch (error) {
+    console.error("Error loading family management page:", error);
+    redirect("/families");
+  }
+}

--- a/src/app/families/page.tsx
+++ b/src/app/families/page.tsx
@@ -1,0 +1,169 @@
+import { redirect } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { familyService } from "@/container";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { Button } from "@/components/ui/button";
+import { Users, Settings, Home } from "lucide-react";
+import { MemberStatus, MemberRole } from "@/types/enums";
+import Link from "next/link";
+
+export default async function FamiliesPage() {
+  const session = await auth();
+
+  if (!session?.user?.uuid) {
+    redirect("/api/auth/signin");
+  }
+
+  try {
+    // 현재 사용자의 가족 정보 조회 (authId 사용)
+    const family = await familyService.getFamilyByUserId(session.user.id);
+
+    if (!family) {
+      redirect("/families/create");
+    }
+
+    // 현재 사용자의 멤버 정보 찾기
+    const currentMember = family.members.find(
+      (member) => member.user.id === session.user.id
+    );
+
+    const isAdmin =
+      currentMember?.role === MemberRole.ADMIN &&
+      currentMember?.status === MemberStatus.ACTIVE;
+
+    return (
+      <div className="min-h-screen bg-gradient-to-br from-blue-50 to-indigo-100 p-4">
+        <div className="max-w-4xl mx-auto space-y-6">
+          {/* 헤더 */}
+          <div className="flex justify-between items-center">
+            <div>
+              <h1 className="text-3xl font-bold text-gray-900">우리 가족</h1>
+              <p className="text-gray-600 mt-1">
+                가족 정보와 구성원을 확인하세요
+              </p>
+            </div>
+            <div className="flex gap-2">
+              <Link href="/">
+                <Button variant="outline" size="sm">
+                  <Home className="w-4 h-4 mr-2" />
+                  홈으로
+                </Button>
+              </Link>
+              {isAdmin && (
+                <Link href="/families/manage">
+                  <Button size="sm">
+                    <Settings className="w-4 h-4 mr-2" />
+                    가족 관리
+                  </Button>
+                </Link>
+              )}
+            </div>
+          </div>
+
+          {/* 가족 정보 카드 */}
+          <Card>
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                <Users className="w-5 h-5" />
+                {family.name}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-blue-600">
+                    {
+                      family.members.filter(
+                        (m) => m.status === MemberStatus.ACTIVE
+                      ).length
+                    }
+                  </div>
+                  <div className="text-sm text-gray-600">활성 멤버</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-green-600">
+                    {family.categories.length}
+                  </div>
+                  <div className="text-sm text-gray-600">카테고리</div>
+                </div>
+                <div className="text-center">
+                  <div className="text-2xl font-bold text-purple-600">
+                    {family.expenses.length}
+                  </div>
+                  <div className="text-sm text-gray-600">지출 내역</div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 가족 구성원 목록 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>가족 구성원</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="space-y-4">
+                {family.members
+                  .filter((member) => member.status === MemberStatus.ACTIVE)
+                  .map((member) => (
+                    <div
+                      key={member.id}
+                      className="flex items-center justify-between p-4 border rounded-lg"
+                    >
+                      <div className="flex items-center gap-3">
+                        <Avatar>
+                          <AvatarImage src={member.user.image || undefined} />
+                          <AvatarFallback>
+                            {member.user.name?.charAt(0) || "?"}
+                          </AvatarFallback>
+                        </Avatar>
+                        <div>
+                          <div className="font-medium">{member.user.name}</div>
+                          <div className="text-sm text-gray-600">
+                            {member.user.email}
+                          </div>
+                        </div>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Badge
+                          variant={
+                            member.role === MemberRole.ADMIN
+                              ? "default"
+                              : "secondary"
+                          }
+                        >
+                          {member.role === MemberRole.ADMIN ? "관리자" : "멤버"}
+                        </Badge>
+                        {member.user.id === session.user.id && (
+                          <Badge variant="outline">나</Badge>
+                        )}
+                      </div>
+                    </div>
+                  ))}
+              </div>
+            </CardContent>
+          </Card>
+
+          {/* 권한 안내 */}
+          {!isAdmin && (
+            <Card className="border-amber-200 bg-amber-50">
+              <CardContent className="pt-6">
+                <div className="flex items-center gap-2 text-amber-800">
+                  <Settings className="w-4 h-4" />
+                  <span className="text-sm">
+                    가족 관리 기능은 관리자만 이용할 수 있습니다.
+                  </span>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
+    );
+  } catch (error) {
+    console.error("Family page error:", error);
+    redirect("/families/create");
+  }
+}

--- a/src/app/join/[code]/page.tsx
+++ b/src/app/join/[code]/page.tsx
@@ -1,0 +1,128 @@
+import { notFound } from "next/navigation";
+import { auth } from "@/lib/auth";
+import { familyInviteService } from "@/container";
+import { JoinFamilyForm } from "@/components/family-invites/JoinFamilyForm";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { CalendarDays, Users } from "lucide-react";
+
+interface JoinFamilyPageProps {
+  params: {
+    code: string;
+  };
+}
+
+export default async function JoinFamilyPage({ params }: JoinFamilyPageProps) {
+  const session = await auth();
+
+  if (!session?.user?.uuid) {
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-md">
+        <Card>
+          <CardHeader>
+            <CardTitle>로그인이 필요합니다</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-muted-foreground mb-4">
+              가족 가계부에 가입하려면 먼저 로그인해주세요.
+            </p>
+            <button
+              onClick={() => (window.location.href = "/api/auth/signin")}
+              className="inline-flex items-center justify-center rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 bg-primary text-primary-foreground hover:bg-primary/90 h-10 px-4 py-2 w-full"
+            >
+              로그인
+            </button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  try {
+    // 초대 정보 조회
+    const inviteInfo = await familyInviteService.getInviteByCode(params.code);
+
+    if (!inviteInfo) {
+      notFound();
+    }
+
+    // 초대 유효성 검사
+    const validation = await familyInviteService.validateInvite(
+      params.code,
+      session.user.uuid
+    );
+
+    return (
+      <div className="container mx-auto px-4 py-8 max-w-md space-y-6">
+        {/* 초대 정보 카드 */}
+        <Card>
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Users className="w-5 h-5" />
+              {inviteInfo.family.name}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div>
+              <p className="text-sm text-muted-foreground">초대자</p>
+              <p className="font-medium">
+                {inviteInfo.inviter.name || inviteInfo.inviter.email}
+              </p>
+            </div>
+
+            <div className="flex items-center gap-2 text-sm">
+              <CalendarDays className="w-4 h-4" />
+              <span>
+                만료: {inviteInfo.expiresAt.toLocaleDateString("ko-KR")}
+              </span>
+            </div>
+
+            {inviteInfo.usageLimit && (
+              <div className="flex justify-between text-sm">
+                <span>사용 횟수</span>
+                <Badge variant="secondary">
+                  {inviteInfo.usedCount} / {inviteInfo.usageLimit}
+                </Badge>
+              </div>
+            )}
+
+            <div>
+              <Badge variant={validation.isValid ? "default" : "destructive"}>
+                {validation.isValid ? "유효한 초대" : "유효하지 않은 초대"}
+              </Badge>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 가입 폼 또는 오류 메시지 */}
+        {validation.isValid ? (
+          <JoinFamilyForm initialInviteCode={params.code} />
+        ) : (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-destructive">
+                초대를 사용할 수 없습니다
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-muted-foreground">
+                {validation.reason?.code === "expired" &&
+                  "이 초대 링크는 만료되었습니다."}
+                {validation.reason?.code === "inactive" &&
+                  "이 초대 링크는 비활성화되었습니다."}
+                {validation.reason?.code === "limit_exceeded" &&
+                  "이 초대 링크의 사용 횟수가 초과되었습니다."}
+                {validation.reason?.code === "already_member" &&
+                  "이미 이 가족의 멤버입니다."}
+                {!validation.reason && "알 수 없는 오류가 발생했습니다."}
+              </p>
+            </CardContent>
+          </Card>
+        )}
+      </div>
+    );
+  } catch (error) {
+    console.error("Error loading invite:", error);
+    notFound();
+  }
+}

--- a/src/components/dashboard/QuickActions.tsx
+++ b/src/components/dashboard/QuickActions.tsx
@@ -1,24 +1,29 @@
-'use client'
+"use client";
 
-import { useRouter } from 'next/navigation'
-import { Card, CardContent } from "@/components/ui/card"
-import { Plus, Settings } from "lucide-react"
+import { useRouter } from "next/navigation";
+import { Card, CardContent } from "@/components/ui/card";
+import { Plus, Settings, Users } from "lucide-react";
 
 export function QuickActions() {
-  const router = useRouter()
+  const router = useRouter();
 
   const handleAddExpenseClick = () => {
-    router.push('/expenses')
-  }
+    router.push("/expenses");
+  };
 
   const handleCategoryClick = () => {
     // TODO: 카테고리 관리 페이지로 이동
-    console.log('카테고리 관리 (미구현)')
-  }
+    console.log("카테고리 관리 (미구현)");
+  };
+
+  const handleFamilyClick = () => {
+    // 로그인한 사용자만 가족 관리 페이지에 접근 가능
+    router.push("/families/manage");
+  };
 
   return (
-    <div className="grid grid-cols-2 gap-4">
-      <Card 
+    <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+      <Card
         className="group hover:shadow-xl transition-all duration-300 cursor-pointer border-0 bg-white/80 backdrop-blur-sm"
         onClick={handleAddExpenseClick}
       >
@@ -35,7 +40,7 @@ export function QuickActions() {
         </CardContent>
       </Card>
 
-      <Card 
+      <Card
         className="group hover:shadow-xl transition-all duration-300 cursor-pointer border-0 bg-white/80 backdrop-blur-sm"
         onClick={handleCategoryClick}
       >
@@ -51,6 +56,23 @@ export function QuickActions() {
           </div>
         </CardContent>
       </Card>
+
+      <Card
+        className="group hover:shadow-xl transition-all duration-300 cursor-pointer border-0 bg-white/80 backdrop-blur-sm"
+        onClick={handleFamilyClick}
+      >
+        <CardContent className="p-6">
+          <div className="flex items-center space-x-4">
+            <div className="w-14 h-14 bg-gradient-to-r from-purple-500 to-purple-600 rounded-2xl flex items-center justify-center group-hover:scale-110 transition-transform duration-300 shadow-lg">
+              <Users className="w-7 h-7 text-white" />
+            </div>
+            <div>
+              <h3 className="font-semibold text-gray-900 mb-1">가족 관리</h3>
+              <p className="text-gray-600 text-sm">초대 및 승인</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
     </div>
-  )
+  );
 }

--- a/src/components/family-invites/CreateInviteForm.tsx
+++ b/src/components/family-invites/CreateInviteForm.tsx
@@ -1,0 +1,144 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  createInviteAction,
+  type ActionResult,
+} from "@/app/actions/family-invite-actions";
+import { toast } from "sonner";
+
+interface CreateInviteFormProps {
+  familyUuid: string;
+}
+
+export function CreateInviteForm({ familyUuid }: CreateInviteFormProps) {
+  const [isLoading, setIsLoading] = useState(false);
+  const [inviteResult, setInviteResult] = useState<{
+    inviteCode: string;
+    expiresAt: Date;
+  } | null>(null);
+
+  const handleSubmit = async (formData: FormData) => {
+    setIsLoading(true);
+    try {
+      // familyUuid를 FormData에 추가
+      formData.set("familyUuid", familyUuid);
+
+      const result: ActionResult = await createInviteAction(formData);
+
+      if (result.success && result.data) {
+        setInviteResult(result.data as { inviteCode: string; expiresAt: Date });
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+        if (result.errors) {
+          result.errors.forEach((error) => toast.error(error));
+        }
+      }
+    } catch {
+      toast.error("초대 링크 생성 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const copyInviteLink = () => {
+    if (inviteResult) {
+      const inviteUrl = `${window.location.origin}/join/${inviteResult.inviteCode}`;
+      navigator.clipboard.writeText(inviteUrl);
+      toast.success("초대 링크가 클립보드에 복사되었습니다.");
+    }
+  };
+
+  if (inviteResult) {
+    const inviteUrl = `${window.location.origin}/join/${inviteResult.inviteCode}`;
+    const expiresAt = new Date(inviteResult.expiresAt);
+
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>초대 링크가 생성되었습니다!</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div>
+            <Label>초대 링크</Label>
+            <div className="flex gap-2">
+              <Input value={inviteUrl} readOnly />
+              <Button onClick={copyInviteLink} variant="outline">
+                복사
+              </Button>
+            </div>
+          </div>
+          <div>
+            <Label>만료 시간</Label>
+            <p className="text-sm text-muted-foreground">
+              {expiresAt.toLocaleDateString("ko-KR", {
+                year: "numeric",
+                month: "long",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </p>
+          </div>
+          <Button
+            onClick={() => setInviteResult(null)}
+            variant="outline"
+            className="w-full"
+          >
+            새 초대 링크 만들기
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>가족 초대 링크 생성</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="expiresInDays">만료 기간 (일)</Label>
+            <Input
+              id="expiresInDays"
+              name="expiresInDays"
+              type="number"
+              min="1"
+              max="30"
+              defaultValue="7"
+              placeholder="7"
+            />
+            <p className="text-sm text-muted-foreground mt-1">
+              초대 링크가 유효할 기간을 설정하세요 (최대 30일)
+            </p>
+          </div>
+
+          <div>
+            <Label htmlFor="usageLimit">사용 횟수 제한 (선택사항)</Label>
+            <Input
+              id="usageLimit"
+              name="usageLimit"
+              type="number"
+              min="1"
+              placeholder="무제한"
+            />
+            <p className="text-sm text-muted-foreground mt-1">
+              설정하지 않으면 무제한으로 사용 가능합니다
+            </p>
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "생성 중..." : "초대 링크 생성"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/family-invites/JoinFamilyForm.tsx
+++ b/src/components/family-invites/JoinFamilyForm.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import {
+  joinFamilyAction,
+  type ActionResult,
+} from "@/app/actions/family-invite-actions";
+import { toast } from "sonner";
+import { MemberStatus } from "@/types/enums";
+
+interface JoinFamilyFormProps {
+  initialInviteCode?: string;
+}
+
+export function JoinFamilyForm({ initialInviteCode }: JoinFamilyFormProps) {
+  const router = useRouter();
+  const [isLoading, setIsLoading] = useState(false);
+  const [joinResult, setJoinResult] = useState<{
+    memberStatus: MemberStatus;
+  } | null>(null);
+
+  const handleSubmit = async (formData: FormData) => {
+    setIsLoading(true);
+    try {
+      const result: ActionResult = await joinFamilyAction(formData);
+
+      if (result.success) {
+        setJoinResult(result.data as { memberStatus: MemberStatus });
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+        if (result.errors) {
+          result.errors.forEach((error) => toast.error(error));
+        }
+      }
+    } catch {
+      toast.error("가족 가입 신청 중 오류가 발생했습니다.");
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  if (joinResult) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>
+            {joinResult.memberStatus === MemberStatus.ACTIVE
+              ? "가족 가입 완료!"
+              : "가입 신청 완료!"}
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          {joinResult.memberStatus === MemberStatus.ACTIVE ? (
+            <div className="text-center space-y-4">
+              <p className="text-green-600">
+                성공적으로 가족에 가입되었습니다!
+              </p>
+              <Button onClick={() => router.push("/families")}>
+                가족 가계부 보기
+              </Button>
+            </div>
+          ) : (
+            <div className="text-center space-y-4">
+              <p className="text-blue-600">
+                가입 신청이 완료되었습니다. 관리자의 승인을 기다려 주세요.
+              </p>
+              <Button onClick={() => router.push("/")} variant="outline">
+                홈으로 돌아가기
+              </Button>
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>가족 가계부 가입</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form action={handleSubmit} className="space-y-4">
+          <div>
+            <Label htmlFor="inviteCode">초대 코드</Label>
+            <Input
+              id="inviteCode"
+              name="inviteCode"
+              defaultValue={initialInviteCode}
+              placeholder="초대 코드를 입력하세요"
+              required
+            />
+            <p className="text-sm text-muted-foreground mt-1">
+              가족 관리자로부터 받은 초대 코드를 입력하세요
+            </p>
+          </div>
+
+          <Button type="submit" className="w-full" disabled={isLoading}>
+            {isLoading ? "가입 신청 중..." : "가입 신청"}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/family-invites/PendingMembersList.tsx
+++ b/src/components/family-invites/PendingMembersList.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import {
+  approveMemberAction,
+  rejectMemberAction,
+  type ActionResult,
+} from "@/app/actions/family-invite-actions";
+import { toast } from "sonner";
+import { Check, X, Clock } from "lucide-react";
+import { MemberStatus, MemberRole } from "@/types/enums";
+
+interface PendingMember {
+  id: string;
+  role: MemberRole;
+  status: MemberStatus;
+  joinedAt: Date;
+  user: {
+    id: string;
+    name: string | null;
+    email: string | null;
+    image: string | null;
+  };
+}
+
+interface PendingMembersListProps {
+  familyUuid: string;
+  pendingMembers: PendingMember[];
+}
+
+export function PendingMembersList({
+  familyUuid,
+  pendingMembers,
+}: PendingMembersListProps) {
+  const [loadingMembers, setLoadingMembers] = useState<Set<string>>(new Set());
+
+  const handleMemberAction = async (
+    userUuid: string,
+    action: "approve" | "reject"
+  ) => {
+    setLoadingMembers((prev) => new Set(prev).add(userUuid));
+
+    try {
+      const formData = new FormData();
+      formData.set("familyUuid", familyUuid);
+      formData.set("userUuid", userUuid);
+
+      const result: ActionResult =
+        action === "approve"
+          ? await approveMemberAction(formData)
+          : await rejectMemberAction(formData);
+
+      if (result.success) {
+        toast.success(result.message);
+      } else {
+        toast.error(result.message);
+        if (result.errors) {
+          result.errors.forEach((error) => toast.error(error));
+        }
+      }
+    } catch {
+      toast.error(
+        `멤버 ${action === "approve" ? "승인" : "거절"} 중 오류가 발생했습니다.`
+      );
+    } finally {
+      setLoadingMembers((prev) => {
+        const newSet = new Set(prev);
+        newSet.delete(userUuid);
+        return newSet;
+      });
+    }
+  };
+
+  if (pendingMembers.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Clock className="w-5 h-5" />
+            대기 중인 멤버
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-muted-foreground text-center py-4">
+            대기 중인 가입 신청이 없습니다.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Clock className="w-5 h-5" />
+          대기 중인 멤버 ({pendingMembers.length})
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          {pendingMembers.map((member) => (
+            <div
+              key={member.id}
+              className="flex items-center justify-between p-4 border rounded-lg"
+            >
+              <div className="flex items-center gap-3">
+                <Avatar>
+                  <AvatarImage src={member.user.image || undefined} />
+                  <AvatarFallback>
+                    {member.user.name?.charAt(0) ||
+                      member.user.email?.charAt(0) ||
+                      "?"}
+                  </AvatarFallback>
+                </Avatar>
+
+                <div>
+                  <div className="flex items-center gap-2">
+                    <span className="font-medium">
+                      {member.user.name || member.user.email}
+                    </span>
+                    <Badge variant="outline">
+                      {member.role === MemberRole.ADMIN ? "관리자" : "멤버"}
+                    </Badge>
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    신청일: {member.joinedAt.toLocaleDateString("ko-KR")}
+                  </p>
+                </div>
+              </div>
+
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={() => handleMemberAction(member.user.id, "approve")}
+                  disabled={loadingMembers.has(member.user.id)}
+                  className="bg-green-600 hover:bg-green-700"
+                >
+                  <Check className="w-4 h-4 mr-1" />
+                  승인
+                </Button>
+                <Button
+                  size="sm"
+                  variant="destructive"
+                  onClick={() => handleMemberAction(member.user.id, "reject")}
+                  disabled={loadingMembers.has(member.user.id)}
+                >
+                  <X className="w-4 h-4 mr-1" />
+                  거절
+                </Button>
+              </div>
+            </div>
+          ))}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/container/index.ts
+++ b/src/container/index.ts
@@ -2,19 +2,23 @@
  * 의존성 주입 컨테이너
  */
 
-import { FamilyRepositoryImpl } from "@/repositories/implementations/family.repository.impl";
 import { ExpenseRepositoryImpl } from "@/repositories/implementations/expense.repository.impl";
+import { FamilyInviteRepositoryImpl } from "@/repositories/implementations/family-invite.repository.impl";
+import { FamilyRepositoryImpl } from "@/repositories/implementations/family.repository.impl";
 import { UserRepositoryImpl } from "@/repositories/implementations/user.repository.impl";
-import { FamilyService } from "@/services/family.service";
-import { ExpenseService } from "@/services/expense.service";
-import { IFamilyRepository } from "@/repositories/interfaces/family.repository";
 import { IExpenseRepository } from "@/repositories/interfaces/expense.repository";
+import { FamilyInviteRepository } from "@/repositories/interfaces/family-invite.repository";
+import { IFamilyRepository } from "@/repositories/interfaces/family.repository";
 import { IUserRepository } from "@/repositories/interfaces/user.repository";
+import { ExpenseService } from "@/services/expense.service";
+import { FamilyInviteService } from "@/services/family-invite.service";
+import { FamilyService } from "@/services/family.service";
 
 // Repository 인스턴스들
 const familyRepository: IFamilyRepository = new FamilyRepositoryImpl();
 const expenseRepository: IExpenseRepository = new ExpenseRepositoryImpl();
 const userRepository: IUserRepository = new UserRepositoryImpl();
+const familyInviteRepository = new FamilyInviteRepositoryImpl();
 
 // Service 인스턴스들
 export const familyService = new FamilyService(
@@ -22,9 +26,19 @@ export const familyService = new FamilyService(
   userRepository
 );
 export const expenseService = new ExpenseService(expenseRepository);
+export const familyInviteService = new FamilyInviteService(
+  familyInviteRepository,
+  familyRepository,
+  userRepository
+);
 
 // 타입 체크용 export
-export type { IFamilyRepository, IExpenseRepository, IUserRepository };
+export type {
+  FamilyInviteRepository,
+  IExpenseRepository,
+  IFamilyRepository,
+  IUserRepository,
+};
 
 /**
  * 컨테이너 사용 예시:

--- a/src/lib/auth-utils.ts
+++ b/src/lib/auth-utils.ts
@@ -2,32 +2,32 @@
  * 인증 관련 유틸리티
  */
 
-import { getServerSession } from 'next-auth'
-import { authOptions } from '@/lib/auth'
-import { NextResponse } from 'next/server'
+import { authOptions } from "@/lib/auth";
+import { getServerSession } from "next-auth";
+import { NextResponse } from "next/server";
 
 // 인증된 사용자 정보 타입
 export interface AuthenticatedUser {
-  id: string
-  name: string | null
-  email: string | null
-  image: string | null
+  id: string;
+  name: string | null;
+  email: string | null;
+  image: string | null;
 }
 
 // 인증된 사용자 정보 가져오기
 export async function getAuthenticatedUser(): Promise<AuthenticatedUser | null> {
-  const session = await getServerSession(authOptions)
-  
+  const session = await getServerSession(authOptions);
+
   if (!session?.user?.id) {
-    return null
+    return null;
   }
 
   return {
     id: session.user.id,
     name: session.user.name || null,
     email: session.user.email || null,
-    image: session.user.image || null
-  }
+    image: session.user.image || null,
+  };
 }
 
 // 인증 필수 API 핸들러 래퍼
@@ -36,21 +36,21 @@ export function withAuth<T extends unknown[]>(
 ) {
   return async (...args: T): Promise<NextResponse> => {
     try {
-      const user = await getAuthenticatedUser()
-      
+      const user = await getAuthenticatedUser();
+
       if (!user) {
-        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 })
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
       }
 
-      return await handler(user, ...args)
+      return await handler(user, ...args);
     } catch (error) {
-      console.error('API Auth Error:', error)
+      console.error("API Auth Error:", error);
       return NextResponse.json(
-        { error: 'Internal server error' },
+        { error: "Internal server error" },
         { status: 500 }
-      )
+      );
     }
-  }
+  };
 }
 
 // 선택적 인증 API 핸들러 래퍼
@@ -59,14 +59,14 @@ export function withOptionalAuth<T extends unknown[]>(
 ) {
   return async (...args: T): Promise<NextResponse> => {
     try {
-      const user = await getAuthenticatedUser()
-      return await handler(user, ...args)
+      const user = await getAuthenticatedUser();
+      return await handler(user, ...args);
     } catch (error) {
-      console.error('API Optional Auth Error:', error)
+      console.error("API Optional Auth Error:", error);
       return NextResponse.json(
-        { error: 'Internal server error' },
+        { error: "Internal server error" },
         { status: 500 }
-      )
+      );
     }
-  }
+  };
 }

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,6 +1,14 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+import crypto from "crypto";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
+}
+
+/**
+ * 초대 링크용 고유 코드를 생성합니다 (32자리)
+ */
+export function generateInviteCode(): string {
+  return crypto.randomBytes(16).toString("hex");
 }

--- a/src/repositories/implementations/family-invite.repository.impl.ts
+++ b/src/repositories/implementations/family-invite.repository.impl.ts
@@ -1,0 +1,261 @@
+import { prisma } from "@/lib/prisma";
+import { generateInviteCode } from "@/lib/utils";
+import { FamilyInvite } from "@prisma/client";
+import {
+  FilterOptions,
+  PaginationOptions,
+  PaginationResult,
+  SortOptions,
+} from "../interfaces/base.repository";
+import {
+  CreateFamilyInviteData,
+  CreateInviteData,
+  FamilyInviteRepository,
+  FamilyInviteWithDetails,
+  UpdateInviteData,
+} from "../interfaces/family-invite.repository";
+
+export class FamilyInviteRepositoryImpl implements FamilyInviteRepository {
+  async findById(id: string): Promise<FamilyInvite | null> {
+    return prisma.familyInvite.findFirst({
+      where: {
+        uuid: id,
+        deletedAt: null,
+      },
+    });
+  }
+
+  async findMany(limit?: number): Promise<FamilyInvite[]> {
+    return prisma.familyInvite.findMany({
+      where: {
+        deletedAt: null,
+      },
+      take: limit,
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  }
+
+  async create(data: CreateInviteData): Promise<FamilyInvite> {
+    return prisma.familyInvite.create({
+      data,
+    });
+  }
+
+  async update(
+    id: string,
+    data: UpdateInviteData
+  ): Promise<FamilyInvite | null> {
+    try {
+      return await prisma.familyInvite.update({
+        where: { uuid: id },
+        data: {
+          ...data,
+          updatedAt: new Date(),
+        },
+      });
+    } catch {
+      return null;
+    }
+  }
+
+  async delete(id: string): Promise<void> {
+    await prisma.familyInvite.update({
+      where: { uuid: id },
+      data: {
+        deletedAt: new Date(),
+      },
+    });
+  }
+
+  async createInvite(data: CreateFamilyInviteData): Promise<FamilyInvite> {
+    const inviteCode = generateInviteCode();
+
+    return prisma.familyInvite.create({
+      data: {
+        familyUuid: data.familyUuid,
+        inviteCode,
+        invitedBy: data.invitedBy,
+        expiresAt: data.expiresAt,
+        usageLimit: data.usageLimit,
+      },
+    });
+  }
+
+  async findByInviteCode(
+    inviteCode: string
+  ): Promise<FamilyInviteWithDetails | null> {
+    return prisma.familyInvite.findFirst({
+      where: {
+        inviteCode,
+        deletedAt: null,
+        isActive: true,
+        expiresAt: {
+          gt: new Date(),
+        },
+      },
+      include: {
+        family: {
+          select: {
+            uuid: true,
+            name: true,
+          },
+        },
+        inviter: {
+          select: {
+            uuid: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+  }
+
+  async findActiveInvitesByFamily(familyUuid: string): Promise<FamilyInvite[]> {
+    return prisma.familyInvite.findMany({
+      where: {
+        familyUuid,
+        deletedAt: null,
+        isActive: true,
+        expiresAt: {
+          gt: new Date(),
+        },
+      },
+      orderBy: {
+        createdAt: "desc",
+      },
+    });
+  }
+
+  async incrementUsageCount(uuid: string): Promise<FamilyInvite> {
+    return prisma.familyInvite.update({
+      where: { uuid },
+      data: {
+        usedCount: {
+          increment: 1,
+        },
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  async deactivateInvite(uuid: string): Promise<FamilyInvite> {
+    return prisma.familyInvite.update({
+      where: { uuid },
+      data: {
+        isActive: false,
+        updatedAt: new Date(),
+      },
+    });
+  }
+
+  async deactivateExpiredInvites(): Promise<number> {
+    const result = await prisma.familyInvite.updateMany({
+      where: {
+        expiresAt: {
+          lt: new Date(),
+        },
+        isActive: true,
+        deletedAt: null,
+      },
+      data: {
+        isActive: false,
+        updatedAt: new Date(),
+      },
+    });
+
+    return result.count;
+  }
+
+  // BaseRepository 인터페이스 구현
+  async findAll(options?: {
+    pagination?: PaginationOptions;
+    sort?: SortOptions;
+    filters?: FilterOptions;
+  }): Promise<PaginationResult<FamilyInvite>> {
+    const page = options?.pagination?.page || 1;
+    const limit = options?.pagination?.limit || 10;
+    const skip = (page - 1) * limit;
+
+    const where = {
+      deletedAt: null,
+      ...options?.filters,
+    };
+
+    const orderBy: Record<string, "asc" | "desc"> = {};
+    if (options?.sort) {
+      orderBy[options.sort.field] = options.sort.order;
+    } else {
+      orderBy.createdAt = "desc";
+    }
+
+    const [data, total] = await Promise.all([
+      prisma.familyInvite.findMany({
+        where,
+        skip,
+        take: limit,
+        orderBy,
+      }),
+      prisma.familyInvite.count({ where }),
+    ]);
+
+    return {
+      data,
+      pagination: {
+        page,
+        limit,
+        total,
+        totalPages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async softDelete(id: string): Promise<boolean> {
+    try {
+      await prisma.familyInvite.update({
+        where: { uuid: id },
+        data: {
+          deletedAt: new Date(),
+        },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async restore(id: string): Promise<boolean> {
+    try {
+      await prisma.familyInvite.update({
+        where: { uuid: id },
+        data: {
+          deletedAt: null,
+        },
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async exists(id: string): Promise<boolean> {
+    const count = await prisma.familyInvite.count({
+      where: {
+        uuid: id,
+        deletedAt: null,
+      },
+    });
+    return count > 0;
+  }
+
+  async count(filters?: FilterOptions): Promise<number> {
+    return prisma.familyInvite.count({
+      where: {
+        deletedAt: null,
+        ...filters,
+      },
+    });
+  }
+}

--- a/src/repositories/interfaces/family-invite.repository.ts
+++ b/src/repositories/interfaces/family-invite.repository.ts
@@ -1,0 +1,68 @@
+import { FamilyInvite } from "@prisma/client";
+import { BaseRepository } from "./base.repository";
+
+export interface CreateInviteData {
+  familyUuid: string;
+  inviteCode: string;
+  invitedBy: string;
+  expiresAt: Date;
+  usageLimit?: number | null;
+}
+
+export interface UpdateInviteData {
+  usageLimit?: number | null;
+  isActive?: boolean;
+  usedCount?: number;
+}
+
+export interface CreateFamilyInviteData {
+  familyUuid: string;
+  invitedBy: string;
+  expiresAt: Date;
+  usageLimit?: number;
+}
+
+export interface FamilyInviteWithDetails extends FamilyInvite {
+  family: {
+    uuid: string;
+    name: string;
+  };
+  inviter: {
+    uuid: string;
+    name: string | null;
+    email: string;
+  };
+}
+
+export interface FamilyInviteRepository
+  extends BaseRepository<FamilyInvite, CreateInviteData, UpdateInviteData> {
+  /**
+   * 초대 링크 생성
+   */
+  createInvite(data: CreateFamilyInviteData): Promise<FamilyInvite>;
+
+  /**
+   * 초대 코드로 초대 정보 조회
+   */
+  findByInviteCode(inviteCode: string): Promise<FamilyInviteWithDetails | null>;
+
+  /**
+   * 가족의 활성 초대 링크 목록 조회
+   */
+  findActiveInvitesByFamily(familyUuid: string): Promise<FamilyInvite[]>;
+
+  /**
+   * 초대 링크 사용 횟수 증가
+   */
+  incrementUsageCount(uuid: string): Promise<FamilyInvite>;
+
+  /**
+   * 초대 링크 비활성화
+   */
+  deactivateInvite(uuid: string): Promise<FamilyInvite>;
+
+  /**
+   * 만료된 초대 링크들 비활성화
+   */
+  deactivateExpiredInvites(): Promise<number>;
+}

--- a/src/repositories/interfaces/family.repository.ts
+++ b/src/repositories/interfaces/family.repository.ts
@@ -3,6 +3,7 @@
  */
 
 import { BaseRepository } from "./base.repository";
+import { MemberStatus, MemberRole } from "@/types/enums";
 
 export interface FamilyData {
   id: string;
@@ -16,7 +17,8 @@ export interface FamilyData {
 export interface FamilyWithDetails extends FamilyData {
   members: Array<{
     id: string;
-    role: string;
+    role: MemberRole;
+    status: MemberStatus;
     joinedAt: Date;
     user: {
       id: string;
@@ -55,19 +57,51 @@ export interface IFamilyRepository
   extends BaseRepository<FamilyData, CreateFamilyData, UpdateFamilyData> {
   // Family 특화 메서드
   findByUserUuid(userUuid: string): Promise<FamilyWithDetails | null>;
+
   findAllByUserUuid(userUuid: string): Promise<FamilyWithDetails[]>;
+
   findWithDetails(id: string): Promise<FamilyWithDetails | null>;
+
   addMember(
     familyId: string,
     userUuid: string,
-    role?: string
+    role?: MemberRole
   ): Promise<boolean>;
+
   removeMember(familyId: string, userUuid: string): Promise<boolean>;
+
   updateMemberRole(
     familyId: string,
     userUuid: string,
-    role: string
+    role: MemberRole
   ): Promise<boolean>;
+
+  updateMemberStatus(
+    familyId: string,
+    userUuid: string,
+    status: MemberStatus
+  ): Promise<boolean>;
+
+  getPendingMembers(familyId: string): Promise<
+    Array<{
+      id: string;
+      role: MemberRole;
+      status: MemberStatus;
+      joinedAt: Date;
+      user: {
+        id: string;
+        name: string | null;
+        email: string | null;
+        image: string | null;
+      };
+    }>
+  >;
+
+  approveMember(familyId: string, userUuid: string): Promise<boolean>;
+
+  rejectMember(familyId: string, userUuid: string): Promise<boolean>;
+
   isMember(familyId: string, userUuid: string): Promise<boolean>;
+
   isAdmin(familyId: string, userUuid: string): Promise<boolean>;
 }

--- a/src/services/family-invite.service.ts
+++ b/src/services/family-invite.service.ts
@@ -1,0 +1,385 @@
+import {
+  CreateFamilyInviteData,
+  FamilyInviteRepository,
+  FamilyInviteWithDetails,
+} from "@/repositories/interfaces/family-invite.repository";
+import { IFamilyRepository } from "@/repositories/interfaces/family.repository";
+import { IUserRepository } from "@/repositories/interfaces/user.repository";
+import {
+  InviteValidationReason,
+  MemberRole,
+  MemberStatus,
+} from "@/types/enums";
+import { FamilyInvite } from "@prisma/client";
+
+export interface CreateInviteRequest {
+  familyUuid: string;
+  invitedBy: string;
+  expiresInDays?: number;
+  usageLimit?: number;
+}
+
+export interface JoinFamilyRequest {
+  inviteCode: string;
+  userUuid: string;
+}
+
+export interface InviteValidationResult {
+  isValid: boolean;
+  reason?: InviteValidationReason;
+  invite?: FamilyInviteWithDetails;
+}
+
+export class FamilyInviteService {
+  constructor(
+    private readonly familyInviteRepository: FamilyInviteRepository,
+    private readonly familyRepository: IFamilyRepository,
+    private readonly userRepository: IUserRepository
+  ) {}
+
+  /**
+   * 초대 링크 생성
+   */
+  async createInvite(request: CreateInviteRequest): Promise<FamilyInvite> {
+    // 관리자 권한 확인
+    const isAdmin = await this.familyRepository.isAdmin(
+      request.familyUuid,
+      request.invitedBy
+    );
+    if (!isAdmin) {
+      throw new Error("초대 링크는 관리자만 생성할 수 있습니다.");
+    }
+
+    const expiresAt = new Date();
+    expiresAt.setDate(expiresAt.getDate() + (request.expiresInDays || 7)); // 기본 7일
+
+    const inviteData: CreateFamilyInviteData = {
+      familyUuid: request.familyUuid,
+      invitedBy: request.invitedBy,
+      expiresAt,
+      usageLimit: request.usageLimit,
+    };
+
+    return await this.familyInviteRepository.createInvite(inviteData);
+  }
+
+  /**
+   * 초대 코드로 초대 정보 조회
+   */
+  async getInviteByCode(
+    inviteCode: string
+  ): Promise<FamilyInviteWithDetails | null> {
+    return await this.familyInviteRepository.findByInviteCode(inviteCode);
+  }
+
+  /**
+   * 초대 코드 유효성 검사
+   */
+  async validateInvite(
+    inviteCode: string,
+    userUuid: string
+  ): Promise<InviteValidationResult> {
+    const invite = await this.familyInviteRepository.findByInviteCode(
+      inviteCode
+    );
+
+    if (!invite) {
+      return { isValid: false, reason: InviteValidationReason.NOT_FOUND };
+    }
+
+    // 만료 확인
+    if (invite.expiresAt < new Date()) {
+      return { isValid: false, reason: InviteValidationReason.EXPIRED, invite };
+    }
+
+    // 활성화 상태 확인
+    if (!invite.isActive) {
+      return {
+        isValid: false,
+        reason: InviteValidationReason.INACTIVE,
+        invite,
+      };
+    }
+
+    // 사용 횟수 제한 확인
+    if (invite.usageLimit && invite.usedCount >= invite.usageLimit) {
+      return {
+        isValid: false,
+        reason: InviteValidationReason.LIMIT_EXCEEDED,
+        invite,
+      };
+    }
+
+    // 이미 멤버인지 확인
+    const isMember = await this.familyRepository.isMember(
+      invite.familyUuid,
+      userUuid
+    );
+    if (isMember) {
+      return {
+        isValid: false,
+        reason: InviteValidationReason.ALREADY_MEMBER,
+        invite,
+      };
+    }
+
+    return { isValid: true, invite };
+  }
+
+  /**
+   * 가족 가입 신청
+   */
+  async joinFamily(request: JoinFamilyRequest): Promise<{
+    success: boolean;
+    message: string;
+    memberStatus?: string;
+  }> {
+    // 초대 코드 유효성 검사
+    const validation = await this.validateInvite(
+      request.inviteCode,
+      request.userUuid
+    );
+
+    if (!validation.isValid || !validation.invite) {
+      const messages = {
+        [InviteValidationReason.EXPIRED.code]: "만료된 초대 링크입니다.",
+        [InviteValidationReason.INACTIVE.code]: "비활성화된 초대 링크입니다.",
+        [InviteValidationReason.LIMIT_EXCEEDED.code]:
+          "초대 링크 사용 횟수가 초과되었습니다.",
+        [InviteValidationReason.NOT_FOUND.code]:
+          "유효하지 않은 초대 코드입니다.",
+        [InviteValidationReason.ALREADY_MEMBER.code]:
+          "이미 해당 가족의 멤버입니다.",
+      };
+
+      return {
+        success: false,
+        message:
+          messages[
+            validation.reason?.code || InviteValidationReason.NOT_FOUND.code
+          ],
+      };
+    }
+
+    try {
+      // 가족 멤버로 추가 (pending 상태)
+      await this.familyRepository.addMember(
+        validation.invite.familyUuid,
+        request.userUuid,
+        MemberRole.MEMBER
+      );
+
+      // 초대 링크 사용 횟수 증가
+      await this.familyInviteRepository.incrementUsageCount(
+        validation.invite.uuid
+      );
+
+      return {
+        success: true,
+        message: "가입 신청이 완료되었습니다. 관리자의 승인을 기다려 주세요.",
+        memberStatus: MemberStatus.PENDING.code,
+      };
+    } catch (error) {
+      console.error("Error joining family:", error);
+      return {
+        success: false,
+        message: "가입 신청 중 오류가 발생했습니다.",
+      };
+    }
+  }
+
+  /**
+   * 가입 신청 승인
+   */
+  async approveMember(
+    familyUuid: string,
+    userUuid: string,
+    adminUuid: string
+  ): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    // 관리자 권한 확인
+    const isAdmin = await this.familyRepository.isAdmin(familyUuid, adminUuid);
+    if (!isAdmin) {
+      return {
+        success: false,
+        message: "멤버 승인은 관리자만 할 수 있습니다.",
+      };
+    }
+
+    try {
+      const success = await this.familyRepository.approveMember(
+        familyUuid,
+        userUuid
+      );
+
+      if (success) {
+        return {
+          success: true,
+          message: "멤버 승인이 완료되었습니다.",
+        };
+      } else {
+        return {
+          success: false,
+          message: "멤버 승인에 실패했습니다.",
+        };
+      }
+    } catch (error) {
+      console.error("Error approving member:", error);
+      return {
+        success: false,
+        message: "멤버 승인 중 오류가 발생했습니다.",
+      };
+    }
+  }
+
+  /**
+   * 가입 신청 거절
+   */
+  async rejectMember(
+    familyUuid: string,
+    userUuid: string,
+    adminUuid: string
+  ): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    // 관리자 권한 확인
+    const isAdmin = await this.familyRepository.isAdmin(familyUuid, adminUuid);
+    if (!isAdmin) {
+      return {
+        success: false,
+        message: "멤버 거절은 관리자만 할 수 있습니다.",
+      };
+    }
+
+    try {
+      const success = await this.familyRepository.rejectMember(
+        familyUuid,
+        userUuid
+      );
+
+      if (success) {
+        return {
+          success: true,
+          message: "가입 신청이 거절되었습니다.",
+        };
+      } else {
+        return {
+          success: false,
+          message: "가입 신청 거절에 실패했습니다.",
+        };
+      }
+    } catch (error) {
+      console.error("Error rejecting member:", error);
+      return {
+        success: false,
+        message: "가입 신청 거절 중 오류가 발생했습니다.",
+      };
+    }
+  }
+
+  /**
+   * 대기 중인 멤버 목록 조회
+   */
+  async getPendingMembers(
+    familyUuid: string,
+    adminUuid: string
+  ): Promise<Array<{
+    id: string;
+    role: string;
+    status: string;
+    joinedAt: Date;
+    user: {
+      id: string;
+      name: string | null;
+      email: string | null;
+      image: string | null;
+    };
+  }> | null> {
+    // 관리자 권한 확인
+    const isAdmin = await this.familyRepository.isAdmin(familyUuid, adminUuid);
+    if (!isAdmin) {
+      return null;
+    }
+
+    const members = await this.familyRepository.getPendingMembers(familyUuid);
+    return members.map((member) => ({
+      ...member,
+      role: member.role.code,
+      status: member.status.code,
+    }));
+  }
+
+  /**
+   * 가족의 활성 초대 링크 목록 조회
+   */
+  async getActiveInvites(
+    familyUuid: string,
+    adminUuid: string
+  ): Promise<FamilyInvite[] | null> {
+    // 관리자 권한 확인
+    const isAdmin = await this.familyRepository.isAdmin(familyUuid, adminUuid);
+    if (!isAdmin) {
+      return null;
+    }
+
+    return await this.familyInviteRepository.findActiveInvitesByFamily(
+      familyUuid
+    );
+  }
+
+  /**
+   * 초대 링크 비활성화
+   */
+  async deactivateInvite(
+    inviteUuid: string,
+    adminUuid: string
+  ): Promise<{
+    success: boolean;
+    message: string;
+  }> {
+    try {
+      const invite = await this.familyInviteRepository.findById(inviteUuid);
+      if (!invite) {
+        return {
+          success: false,
+          message: "초대 링크를 찾을 수 없습니다.",
+        };
+      }
+
+      // 관리자 권한 확인
+      const isAdmin = await this.familyRepository.isAdmin(
+        invite.familyUuid,
+        adminUuid
+      );
+      if (!isAdmin) {
+        return {
+          success: false,
+          message: "초대 링크 비활성화는 관리자만 할 수 있습니다.",
+        };
+      }
+
+      await this.familyInviteRepository.deactivateInvite(inviteUuid);
+
+      return {
+        success: true,
+        message: "초대 링크가 비활성화되었습니다.",
+      };
+    } catch (error) {
+      console.error("Error deactivating invite:", error);
+      return {
+        success: false,
+        message: "초대 링크 비활성화 중 오류가 발생했습니다.",
+      };
+    }
+  }
+
+  /**
+   * 만료된 초대 링크들 정리 (크론 작업용)
+   */
+  async cleanupExpiredInvites(): Promise<number> {
+    return await this.familyInviteRepository.deactivateExpiredInvites();
+  }
+}

--- a/src/services/family.service.ts
+++ b/src/services/family.service.ts
@@ -3,11 +3,12 @@
  */
 
 import {
-  IFamilyRepository,
-  FamilyWithDetails,
   CreateFamilyData,
+  FamilyWithDetails,
+  IFamilyRepository,
 } from "@/repositories/interfaces/family.repository";
 import { IUserRepository } from "@/repositories/interfaces/user.repository";
+import { MemberRole } from "@/types/enums";
 
 export class FamilyService {
   constructor(
@@ -46,7 +47,11 @@ export class FamilyService {
     const family = await this.familyRepository.create(data);
 
     // 생성된 Family에 첫 번째 멤버로 사용자 추가 (admin 권한)
-    await this.familyRepository.addMember(family.uuid, user.uuid, "admin");
+    await this.familyRepository.addMember(
+      family.uuid,
+      user.uuid,
+      MemberRole.ADMIN
+    );
 
     // 생성된 가족의 상세 정보를 다시 조회
     const familyWithDetails = await this.familyRepository.findWithDetails(
@@ -97,7 +102,7 @@ export class FamilyService {
   async addMember(
     familyId: string,
     userId: string,
-    role: string = "member"
+    role: MemberRole = MemberRole.MEMBER
   ): Promise<boolean> {
     // userId는 User.authId이므로, 먼저 User.uuid를 찾음
     const user = await this.userRepository.findByAuthId(userId);
@@ -117,7 +122,7 @@ export class FamilyService {
   async updateMemberRole(
     familyId: string,
     userId: string,
-    role: string
+    role: MemberRole
   ): Promise<boolean> {
     // userId는 User.authId이므로, 먼저 User.uuid를 찾음
     const user = await this.userRepository.findByAuthId(userId);

--- a/src/types/code-enum.ts
+++ b/src/types/code-enum.ts
@@ -1,0 +1,47 @@
+/**
+ * CodeEnum 추상 클래스
+ * 모든 enum은 code 값을 가지고, DB와의 매핑을 자동화
+ */
+export abstract class CodeEnum {
+  constructor(public readonly code: string, public readonly name: string) {}
+
+  toString(): string {
+    return this.code;
+  }
+
+  equals(other: CodeEnum): boolean {
+    return this.code === other.code;
+  }
+
+  static fromCode<T extends CodeEnum>(
+    enumClass: Record<string, T>,
+    code: string
+  ): T {
+    const values = Object.values(enumClass) as T[];
+    const found = values.find((value) => value.code === code);
+    if (!found) {
+      throw new Error(`Invalid code: ${code} for enum`);
+    }
+    return found;
+  }
+
+  static getAllCodes<T extends CodeEnum>(
+    enumClass: Record<string, T>
+  ): string[] {
+    return Object.values(enumClass).map((value: T) => value.code);
+  }
+
+  static getAllValues<T extends CodeEnum>(enumClass: Record<string, T>): T[] {
+    return Object.values(enumClass) as T[];
+  }
+}
+
+/**
+ * CodeEnum을 위한 유틸리티 타입
+ */
+export type CodeEnumType<T extends CodeEnum> = {
+  new (code: string, name: string): T;
+  fromCode(code: string): T;
+  getAllCodes(): string[];
+  getAllValues(): T[];
+};

--- a/src/types/enums.ts
+++ b/src/types/enums.ts
@@ -1,0 +1,161 @@
+/**
+ * 가족 구성원 상태 enum
+ */
+export class MemberStatus {
+  static readonly PENDING = new MemberStatus("pending", "가입 신청 대기");
+  static readonly APPROVED = new MemberStatus("approved", "승인됨");
+  static readonly REJECTED = new MemberStatus("rejected", "거절됨");
+  static readonly ACTIVE = new MemberStatus("active", "활성 멤버");
+
+  private constructor(
+    public readonly code: string,
+    public readonly name: string
+  ) {}
+
+  static fromCode(code: string): MemberStatus {
+    switch (code) {
+      case "pending":
+        return MemberStatus.PENDING;
+      case "approved":
+        return MemberStatus.APPROVED;
+      case "rejected":
+        return MemberStatus.REJECTED;
+      case "active":
+        return MemberStatus.ACTIVE;
+      default:
+        throw new Error(`Invalid MemberStatus code: ${code}`);
+    }
+  }
+
+  static getAllCodes(): string[] {
+    return [
+      MemberStatus.PENDING.code,
+      MemberStatus.APPROVED.code,
+      MemberStatus.REJECTED.code,
+      MemberStatus.ACTIVE.code,
+    ];
+  }
+
+  static getAllValues(): MemberStatus[] {
+    return [
+      MemberStatus.PENDING,
+      MemberStatus.APPROVED,
+      MemberStatus.REJECTED,
+      MemberStatus.ACTIVE,
+    ];
+  }
+}
+
+/**
+ * 가족 구성원 역할 enum
+ */
+export class MemberRole {
+  static readonly ADMIN = new MemberRole("admin", "관리자");
+  static readonly MEMBER = new MemberRole("member", "일반 멤버");
+
+  private constructor(
+    public readonly code: string,
+    public readonly name: string
+  ) {}
+
+  static fromCode(code: string): MemberRole {
+    switch (code) {
+      case "admin":
+        return MemberRole.ADMIN;
+      case "member":
+        return MemberRole.MEMBER;
+      default:
+        throw new Error(`Invalid MemberRole code: ${code}`);
+    }
+  }
+
+  static getAllCodes(): string[] {
+    return [MemberRole.ADMIN.code, MemberRole.MEMBER.code];
+  }
+
+  static getAllValues(): MemberRole[] {
+    return [MemberRole.ADMIN, MemberRole.MEMBER];
+  }
+}
+
+/**
+ * 초대 링크 상태 enum
+ */
+export enum InviteStatus {
+  ACTIVE = "active", // 활성
+  INACTIVE = "inactive", // 비활성
+  EXPIRED = "expired", // 만료
+}
+
+/**
+ * 초대 검증 실패 이유 enum
+ */
+export class InviteValidationReason {
+  static readonly EXPIRED = new InviteValidationReason("expired", "만료됨");
+  static readonly INACTIVE = new InviteValidationReason(
+    "inactive",
+    "비활성화됨"
+  );
+  static readonly LIMIT_EXCEEDED = new InviteValidationReason(
+    "limit_exceeded",
+    "사용 횟수 초과"
+  );
+  static readonly NOT_FOUND = new InviteValidationReason(
+    "not_found",
+    "찾을 수 없음"
+  );
+  static readonly ALREADY_MEMBER = new InviteValidationReason(
+    "already_member",
+    "이미 멤버임"
+  );
+
+  private constructor(
+    public readonly code: string,
+    public readonly name: string
+  ) {}
+
+  static fromCode(code: string): InviteValidationReason {
+    switch (code) {
+      case "expired":
+        return InviteValidationReason.EXPIRED;
+      case "inactive":
+        return InviteValidationReason.INACTIVE;
+      case "limit_exceeded":
+        return InviteValidationReason.LIMIT_EXCEEDED;
+      case "not_found":
+        return InviteValidationReason.NOT_FOUND;
+      case "already_member":
+        return InviteValidationReason.ALREADY_MEMBER;
+      default:
+        throw new Error(`Invalid InviteValidationReason code: ${code}`);
+    }
+  }
+
+  static getAllCodes(): string[] {
+    return [
+      InviteValidationReason.EXPIRED.code,
+      InviteValidationReason.INACTIVE.code,
+      InviteValidationReason.LIMIT_EXCEEDED.code,
+      InviteValidationReason.NOT_FOUND.code,
+      InviteValidationReason.ALREADY_MEMBER.code,
+    ];
+  }
+
+  static getAllValues(): InviteValidationReason[] {
+    return [
+      InviteValidationReason.EXPIRED,
+      InviteValidationReason.INACTIVE,
+      InviteValidationReason.LIMIT_EXCEEDED,
+      InviteValidationReason.NOT_FOUND,
+      InviteValidationReason.ALREADY_MEMBER,
+    ];
+  }
+}
+
+/**
+ * 가족 타입 enum
+ */
+export enum FamilyType {
+  PERSONAL = "personal", // 개인 가계부
+  FAMILY = "family", // 가족 가계부
+}

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,12 +1,13 @@
-import "next-auth"
+import "next-auth";
 
 declare module "next-auth" {
   interface Session {
     user: {
-      id: string
-      name?: string | null
-      email?: string | null
-      image?: string | null
-    }
+      id: string;
+      uuid: string;
+      name?: string | null;
+      email?: string | null;
+      image?: string | null;
+    };
   }
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Implements a full family invitation flow (create/join/approve/reject) with new DB schema, repositories/services, server actions, pages/components, and auth/type updates using enum-based roles/status.
> 
> - **Database**:
>   - Add `family_invites` table with usage limits, expiration, and inviter relation; indexes and FKs.
>   - Convert `family_members.role/status` to enums `MemberRole`/`MemberStatus`; add `status` and related defaults.
>   - Update Prisma schema to include `FamilyInvite` model and relations.
> - **Backend**:
>   - Repositories: new `FamilyInviteRepositoryImpl`; extend `FamilyRepositoryImpl` with enum-aware member role/status, pending member queries, approve/reject.
>   - Services: new `FamilyInviteService` (create/validate/join/approve/reject/getActiveInvites/cleanup); update `FamilyService` to use enum roles.
>   - Server actions: `createInviteAction`, `joinFamilyAction`, `approveMemberAction`, `rejectMemberAction`, `deactivateInviteAction`.
>   - Container wiring: register `familyInviteService` and repository.
> - **Auth/Types/Utils**:
>   - Add `session.user.uuid` via `auth` callback; extend `next-auth` types; add enum types (`MemberRole`, `MemberStatus`, `InviteValidationReason`) and `generateInviteCode`.
> - **Frontend**:
>   - Pages: `app/families`, `app/families/manage`, `app/join/[code]` for viewing/managing family, invites, and joining.
>   - Components: `CreateInviteForm`, `JoinFamilyForm`, `PendingMembersList`; update `QuickActions` with “가족 관리” shortcut.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b4cac375e28817df6e77ded439b47e2f1590b12a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->